### PR TITLE
Use DeviceCreationFlags.Debug only when attached to a debugger

### DIFF
--- a/Xe.Drawing.Direct3D/Drawing.Context.cs
+++ b/Xe.Drawing.Direct3D/Drawing.Context.cs
@@ -73,9 +73,11 @@ namespace Xe.Drawing
 
             internal CDevice()
             {
-                var flags = d3d.DeviceCreationFlags.BgraSupport |
-                    //d3d.DeviceCreationFlags.VideoSupport |
-                    d3d.DeviceCreationFlags.Debug;
+                var flags = d3d.DeviceCreationFlags.BgraSupport;
+
+                #if DEBUG
+                flags |= d3d.DeviceCreationFlags.Debug;
+                #endif
 
                 d3dDevice = new d3d.Device(DriverType.Hardware, flags);
                 d3dDevice1 = d3dDevice.QueryInterface<d3d.Device1>();


### PR DESCRIPTION
see https://docs.microsoft.com/en-us/windows/win32/direct3d11/overviews-direct3d-11-devices-layers