### PR TITLE
Allow BarEditor to launch ImageViewer without error.

### DIFF
--- a/Xe.Tools/Plugins.cs
+++ b/Xe.Tools/Plugins.cs
@@ -30,6 +30,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using Xe.Tools.Utilities;
 
 namespace Xe.Tools
 {
@@ -39,6 +40,8 @@ namespace Xe.Tools
 	/// <typeparam name="T"></typeparam>
 	public static class Plugins
 	{
+		private readonly static PluginLoadContext loader = new PluginLoadContext();
+
 		public static IEnumerable<(Assembly, Type)> GetPlugins(string folder, Func<string, bool> assemblyFilter,
 			Func<Type, bool> typeFilter)
 		{
@@ -54,7 +57,7 @@ namespace Xe.Tools
 			var plugins = new List<(Assembly, Type)>();
 			foreach (var file in fileNames)
 			{
-				var assembly = Assembly.LoadFile(file);
+				var assembly = loader.LoadFromAssemblyPath(file);
 				foreach (var type in assembly.GetTypes())
 				{
 					if (typeFilter.Invoke(type))

--- a/Xe.Tools/Utilities/PluginLoadContext.cs
+++ b/Xe.Tools/Utilities/PluginLoadContext.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Runtime.Loader;
+using System.Text;
+
+namespace Xe.Tools.Utilities
+{
+    /// <summary>
+    /// Avoid to raise TypeInitializationException on trying load referencedAssembly from plugin dll.
+    /// </summary>
+    class PluginLoadContext : AssemblyLoadContext
+    {
+        public PluginLoadContext()
+        {
+            Resolving += NeedToResolveNotLoadedAssembly;
+        }
+
+        private Assembly NeedToResolveNotLoadedAssembly(AssemblyLoadContext loader, AssemblyName assemblyName)
+        {
+            var dllName = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, assemblyName.Name + ".dll");
+            if (File.Exists(dllName))
+            {
+                var assembly = Assembly.LoadFrom(dllName);
+                if (assembly != null && assembly.FullName == assemblyName.FullName)
+                {
+                    return assembly;
+                }
+            }
+            return null;
+        }
+
+        protected override Assembly Load(AssemblyName assemblyName)
+        {
+            return null;
+        }
+    }
+}

--- a/Xe.Tools/Xe.Tools.csproj
+++ b/Xe.Tools/Xe.Tools.csproj
@@ -4,6 +4,9 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\Xe\Xe.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Implement PluginLoadContext.
- Hook `Resolving` in order to allow loading assemblies that are not listed in entry assembly's referencedAssemblies like `OpenKh.Bbs`.